### PR TITLE
Initialize Next.js application

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "next/core-web-vitals"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+# Dependencies
+/node_modules
+
+# Production
+/.next
+/out
+
+# Misc
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.next
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,2 +1,26 @@
 # codex-test
-# codex-test
+
+This repository now contains a minimal [Next.js](https://nextjs.org/) application.
+
+## Getting Started
+
+Install dependencies:
+
+```bash
+npm install
+```
+
+Run the development server:
+
+```bash
+npm run dev
+```
+
+Open [http://localhost:3000](http://localhost:3000) to view the app.
+
+## Available Scripts
+
+- `npm run dev` – start the development server with hot reload.
+- `npm run build` – create an optimized production build.
+- `npm run start` – run the production build.
+- `npm run lint` – run ESLint with Next.js defaults.

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,18 @@
+:root {
+  color-scheme: light dark;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+body {
+  margin: 0;
+}
+
+h1 {
+  font-size: clamp(2rem, 5vw, 3.5rem);
+  margin-bottom: 1rem;
+}
+
+p {
+  font-size: 1.125rem;
+  line-height: 1.6;
+}

--- a/app/layout.js
+++ b/app/layout.js
@@ -1,0 +1,14 @@
+import './globals.css';
+
+export const metadata = {
+  title: 'codex-test',
+  description: 'Generated with Next.js',
+};
+
+export default function RootLayout({ children }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/app/page.js
+++ b/app/page.js
@@ -1,0 +1,10 @@
+export default function Home() {
+  return (
+    <main style={{ display: 'flex', minHeight: '100vh', alignItems: 'center', justifyContent: 'center' }}>
+      <div style={{ textAlign: 'center' }}>
+        <h1>Welcome to codex-test</h1>
+        <p>This project is now powered by Next.js.</p>
+      </div>
+    </main>
+  );
+}

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "paths": {
+      "@/*": ["./*"]
+    }
+  }
+}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,4 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {};
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "codex-test",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.1.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  }
+}


### PR DESCRIPTION
## Summary
- bootstrap a minimal Next.js application with app router, global styles, and base layout/page
- add Next.js configuration, linting, and project metadata files along with updated README instructions

## Testing
- ⚠️ `npm install` *(fails: registry access is forbidden in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d4c07895708333b5e06fa3f505651e